### PR TITLE
HZN-629: created blueprint file and junit

### DIFF
--- a/features/events/traps/blueprint-trapd-listener.xml
+++ b/features/events/traps/blueprint-trapd-listener.xml
@@ -1,0 +1,33 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xsi:schemaLocation="
+        http://www.osgi.org/xmlns/blueprint/v1.0.0 
+        http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+        http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+        http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+        http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
+        http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+">
+
+    <cm:property-placeholder id="trapdProperties" persistent-id="org.opennms.netmgt.trapd" update-strategy="none">
+        <cm:default-properties>
+            <cm:property name="trapd.listen.interface" value="127.0.0.1" />
+            <cm:property name="trapd.listen.port" value="5150" />
+        </cm:default-properties>
+    </cm:property-placeholder>
+    
+    <bean id="trapdConfig" class="org.opennms.netmgt.trapd.TrapdConfigBean">
+        <property name="snmpTrapPort" value="${trapd.listen.port}"/>
+        <property name="snmpTrapAddress" value="${trapd.listen.interface}"/>
+    </bean>
+
+    <reference id="trapNotificationHandlers" interface="org.opennms.netmgt.trapd.TrapNotificationHandler"/>
+
+    <bean id="trapdListenerJava" class="org.opennms.netmgt.trapd.TrapReceiverSnmp4jImpl" init-method="start" destroy-method="stop">
+        <argument ref="trapdConfig"/>
+        <property name="trapNotificationHandlers" ref="trapNotificationHandlers"/>
+    </bean>
+
+</blueprint>

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -122,5 +122,11 @@
       <artifactId>org.opennms.features.collection.persistence.rrd</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>camel-test-dependencies</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.trapd;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.apache.camel.util.KeyValueHolder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.netmgt.snmp.TrapNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:/META-INF/opennms/emptyContext.xml" })
+public class TrapdListenerBlueprintIT extends CamelBlueprintTestSupport {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TrapdListenerBlueprintIT.class);
+
+	/**
+	 * Use Aries Blueprint synchronous mode to avoid a blueprint deadlock bug.
+	 * 
+	 * @see https://issues.apache.org/jira/browse/ARIES-1051
+	 * @see https://access.redhat.com/site/solutions/640943
+	 */
+	@Override
+	public void doPreSetup() throws Exception {
+		System.setProperty("org.apache.aries.blueprint.synchronous", Boolean.TRUE.toString());
+		System.setProperty("de.kalpatec.pojosr.framework.events.sync", Boolean.TRUE.toString());
+	}
+
+	@Override
+	public boolean isUseAdviceWith() {
+		return true;
+	}
+
+	@Override
+	public boolean isUseDebugger() {
+		// must enable debugger
+		return true;
+	}
+
+	@Override
+	public String isMockEndpoints() {
+		return "*";
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	protected void addServicesOnStartup(Map<String, KeyValueHolder<Object, Dictionary>> services) {
+		// Register any mock OSGi services here
+		services.put(TrapNotificationHandler.class.getName(), new KeyValueHolder<Object, Dictionary>(new TrapNotificationHandler() {
+
+			@Override
+			public void handleTrapNotification(TrapNotification message) {
+				// TODO Auto-generated method stub
+				
+			}
+
+		}, new Properties()));
+	}
+
+	// The location of our Blueprint XML files to be used for testing
+	@Override
+	protected String getBlueprintDescriptor() {
+		return "file:blueprint-trapd-listener.xml,file:src/test/resources/blueprint-empty-camel-context.xml";
+	}
+
+	@Test
+	public void testTrapd() throws Exception {
+		// TODO: Perform integration testing
+	}
+}

--- a/features/events/traps/src/test/resources/blueprint-empty-camel-context.xml
+++ b/features/events/traps/src/test/resources/blueprint-empty-camel-context.xml
@@ -1,0 +1,16 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+	xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+	xsi:schemaLocation="
+		http://www.osgi.org/xmlns/blueprint/v1.0.0 
+		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+">
+
+	<camelContext id="emptyCamelContext" xmlns="http://camel.apache.org/schema/blueprint"/>
+
+</blueprint>


### PR DESCRIPTION
HZN-629
Create blueprint.xml for the Trapd receiver.

The junit is failing at SnmpUtils.registerForTraps(this, this, address, m_snmpTrapPort, m_snmpV3Users); 
Because the list of SnmpV3Users is null.

Need info/help in creating this list of SnmpV3Users. 
