### PR TITLE
HZN-703: Change blueprint-trapd-handler-minion.xml to use Minion ActiveMQ Component

### DIFF
--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -31,6 +31,7 @@
     
     <feature name="opennms-trapd-handler-minion" description="OpenNMS :: Trapd :: Handler :: Minion" version="${project.version}">
       <feature>camel-blueprint</feature>
+      <feature>minion-core-api</feature>
       <feature>opennms-trapd</feature>
 
       <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/xml/blueprint-trapd-handler-minion</bundle>

--- a/features/events/traps/blueprint-trapd-handler-minion.xml
+++ b/features/events/traps/blueprint-trapd-handler-minion.xml
@@ -25,13 +25,8 @@
 	<service interface="org.opennms.netmgt.trapd.TrapNotificationHandler" ref="trapdNotificationHandlerCamel" />
 
 
-	<bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-		<!-- TODO: HZN-490 Add configurable ActiveMQ URI -->
-		<property name="brokerURL" value="${brokerUri}" />
-		<!-- TODO: HZN-490 Add configurable authentication -->
-		<!-- <property name="userName" value="karaf" /> <property name="password" 
-			value="karaf" /> -->
-	</bean>
+	<!-- ActiveMQ component provided by minion-core -->
+    <reference id="activemq" interface="org.apache.camel.Component"/>
 
 	<camelContext id="trapdNotificationHandlerMinion"
 		xmlns="http://camel.apache.org/schema/blueprint">

--- a/features/events/traps/blueprint-trapd-handler-minion.xml
+++ b/features/events/traps/blueprint-trapd-handler-minion.xml
@@ -26,7 +26,7 @@
 
 
 	<!-- ActiveMQ component provided by minion-core -->
-    <reference id="activemq" interface="org.apache.camel.Component"/>
+    <reference id="queuingservice" interface="org.apache.camel.Component" filter="(alias=opennms.broker)"/>
 
 	<camelContext id="trapdNotificationHandlerMinion"
 		xmlns="http://camel.apache.org/schema/blueprint">
@@ -36,7 +36,7 @@
 			<convertBodyTo type="org.opennms.netmgt.trapd.TrapQueueProcessor" />
 			<!-- TODO: Use marshalling instead of serialization when transmitting object? -->
 			<!-- Broadcast message over ActiveMQ -->
-			<to uri="activemq:broadcastTrap?disableReplyTo=true" />
+			<to uri="queuingservice:broadcastTrap?disableReplyTo=true" />
 		</route>
 	</camelContext>
 

--- a/features/events/traps/blueprint-trapd-handler-minion.xml
+++ b/features/events/traps/blueprint-trapd-handler-minion.xml
@@ -27,7 +27,7 @@
 
 	<!-- ActiveMQ component provided by minion-core -->
     <reference id="queuingservice" interface="org.apache.camel.Component" filter="(alias=opennms.broker)"/>
-
+    
 	<camelContext id="trapdNotificationHandlerMinion"
 		xmlns="http://camel.apache.org/schema/blueprint">
 		<propertyPlaceholder id="properties" location="blueprint:trapdNotificationHandlerMinionProperties" />

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdHandlerMinionIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdHandlerMinionIT.java
@@ -30,8 +30,11 @@ package org.opennms.netmgt.trapd;
 
 import java.util.Dictionary;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.camel.component.ActiveMQComponent;
+import org.apache.camel.Component;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.apache.camel.util.KeyValueHolder;
@@ -41,6 +44,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.config.TrapdConfig;
+import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.snmp.BasicTrapProcessor;
 import org.opennms.netmgt.snmp.TrapNotification;
 import org.opennms.netmgt.snmp.TrapProcessor;
@@ -63,7 +68,7 @@ public class TrapdHandlerMinionIT extends CamelBlueprintTestSupport {
 	private static final Logger LOG = LoggerFactory.getLogger(TrapdHandlerMinionIT.class);
 
 	private static BrokerService m_broker = null;
-
+	
 	/**
 	 * Use Aries Blueprint synchronous mode to avoid a blueprint deadlock bug.
 	 * 
@@ -95,7 +100,25 @@ public class TrapdHandlerMinionIT extends CamelBlueprintTestSupport {
 	@SuppressWarnings("rawtypes")
 	@Override
 	protected void addServicesOnStartup(Map<String, KeyValueHolder<Object, Dictionary>> services) {
-		// Register any mock OSGi services here
+
+		// Create a mock TrapdConfigBean
+		TrapdConfigBean config = new TrapdConfigBean();
+		config.setSnmpTrapPort(10514);
+		config.setSnmpTrapAddress("127.0.0.1");
+		config.setNewSuspectOnTrap(false);
+
+     	services.put(TrapdConfig.class.getName(),
+     				new KeyValueHolder<Object, Dictionary>(config, new Properties()));
+
+
+        Properties props = new Properties();
+        props.setProperty("alias", "opennms.broker");
+        
+        //creating the Active MQ component and service
+        ActiveMQComponent activeMQ = new ActiveMQComponent();
+        activeMQ.setBrokerURL("tcp://127.0.0.1:61716");
+        services.put( Component.class.getName(),
+                new KeyValueHolder<Object, Dictionary>( activeMQ, props ) );
 	}
 
 	// The location of our Blueprint XML files to be used for testing
@@ -121,13 +144,22 @@ public class TrapdHandlerMinionIT extends CamelBlueprintTestSupport {
 	@Test
 	public void testTrapd() throws Exception {
 		
-		MockEndpoint broadcasTrap = getMockEndpoint("mock:activemq:broadcastTrap", false);
+		MockEndpoint broadcasTrap = getMockEndpoint("mock:queuingservice:broadcastTrap", false);
 		broadcasTrap.setExpectedMessageCount(1);
+		
+		MockEventIpcManager mockEventIpcManager = new MockEventIpcManager();
+
+		MockTrapdIpMgr m_trapdIpMgr=new MockTrapdIpMgr();
+
+		m_trapdIpMgr.clearKnownIpsMap();
+		m_trapdIpMgr.setNodeId("127.0.0.1", 1);
 
 
 		TrapQueueProcessor trap=new TrapQueueProcessor();
 		trap.setNewSuspect(false);
-		TrapProcessor trapProcess = new BasicTrapProcessor();
+		trap.setEventManager(mockEventIpcManager);
+		
+		EventCreator trapProcess = new EventCreator(m_trapdIpMgr);
 		trapProcess.setAgentAddress(InetAddressUtils.ONE_TWENTY_SEVEN);
 		trapProcess.setCommunity("comm");
 		trapProcess.setTrapAddress(InetAddressUtils.ONE_TWENTY_SEVEN);


### PR DESCRIPTION
HZN-703:
- Changed to use activeMQ from minion core.
- Added minion core dependency to the 'opennms-trapd-handler-minion'
